### PR TITLE
Small touch-up for scripts in general

### DIFF
--- a/Assets/UI/Scripts/ExitScene.gd
+++ b/Assets/UI/Scripts/ExitScene.gd
@@ -1,5 +1,4 @@
 extends Node
 
-func _process(_delta):
+func _ready():
 	get_tree().quit()
-	pass

--- a/Assets/UI/Scripts/Main/CloseMenu.gd
+++ b/Assets/UI/Scripts/Main/CloseMenu.gd
@@ -1,10 +1,9 @@
 extends BaseButton
 
-var parent # : VBoxContainer
+var _parent # : VBoxContainer
 
 func _ready():
-	parent = get_parent()
+	_parent = get_parent()
 
 func _pressed():
-	parent.toggle_visible()
-	pass
+	_parent.toggle_visible()

--- a/Assets/UI/Scripts/Main/Connect.gd
+++ b/Assets/UI/Scripts/Main/Connect.gd
@@ -1,7 +1,8 @@
 extends BaseButton
 
-#var scene = load("res://Assets/World/World.tscn") # : PackedScene
+#var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
 
 func _pressed():
-	#var _stfu = get_tree().change_scene_to(scene)
+	#warning-ignore:return_value_discarded
+	#get_tree().change_scene_to(_scene)
 	pass

--- a/Assets/UI/Scripts/Main/EditorButton.gd
+++ b/Assets/UI/Scripts/Main/EditorButton.gd
@@ -1,7 +1,8 @@
 extends BaseButton
 
-#var scene = load("res://Assets/World/World.tscn") # : PackedScene
+#var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
 
 func _pressed():
-	#var _stfu = get_tree().change_scene_to(scene)
+	#warning-ignore:return_value_discarded
+	#get_tree().change_scene_to(_scene)
 	pass

--- a/Assets/UI/Scripts/Main/ExitGame.gd
+++ b/Assets/UI/Scripts/Main/ExitGame.gd
@@ -1,7 +1,7 @@
 extends BaseButton
 
-var scene = load("res://Assets/UI/Scenes/ExitScene.tscn") # : PackedScene
+var _scene = preload("res://Assets/UI/Scenes/ExitScene.tscn") # : PackedScene
 
 func _pressed():
-	var _stfu = get_tree().change_scene_to(scene)
-	pass
+	#warning-ignore:return_value_discarded
+	get_tree().change_scene_to(_scene)

--- a/Assets/UI/Scripts/Main/HelpButton.gd
+++ b/Assets/UI/Scripts/Main/HelpButton.gd
@@ -1,7 +1,8 @@
 extends BaseButton
 
-#var scene = load("res://Assets/World/World.tscn") # : PackedScene
+#var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
 
 func _pressed():
-	#var _stfu = get_tree().change_scene_to(scene)
+	#warning-ignore:return_value_discarded
+	#get_tree().change_scene_to(_scene)
 	pass

--- a/Assets/UI/Scripts/Main/LoadGame.gd
+++ b/Assets/UI/Scripts/Main/LoadGame.gd
@@ -1,7 +1,7 @@
 extends BaseButton
 
-var scene = load("res://Assets/World/World.tscn") # : PackedScene
+var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
 
 func _pressed():
-	var _stfu = get_tree().change_scene_to(scene)
-	pass
+	#warning-ignore:return_value_discarded
+	get_tree().change_scene_to(_scene)

--- a/Assets/UI/Scripts/Main/LogButton.gd
+++ b/Assets/UI/Scripts/Main/LogButton.gd
@@ -1,7 +1,8 @@
 extends BaseButton
 
-#var scene = load("res://Assets/World/World.tscn") # : PackedScene
+#var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
 
 func _pressed():
-	#var _stfu = get_tree().change_scene_to(scene)
+	#warning-ignore:return_value_discarded
+	#get_tree().change_scene_to(_scene)
 	pass

--- a/Assets/UI/Scripts/Main/NewGame.gd
+++ b/Assets/UI/Scripts/Main/NewGame.gd
@@ -1,7 +1,7 @@
 extends BaseButton
 
-var scene = load("res://Assets/World/World.tscn") # : PackedScene
+var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
 
 func _pressed():
-	var _stfu = get_tree().change_scene_to(scene)
-	pass
+	#warning-ignore:return_value_discarded
+	get_tree().change_scene_to(_scene)

--- a/Assets/UI/Scripts/Main/Options.gd
+++ b/Assets/UI/Scripts/Main/Options.gd
@@ -1,7 +1,8 @@
 extends BaseButton
 
-#var scene = load("res://Assets/World/World.tscn") # : PackedScene
+#var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
 
 func _pressed():
-	#var _stfu = get_tree().change_scene_to(scene)
+	#warning-ignore:return_value_discarded
+	#get_tree().change_scene_to(_scene)
 	pass

--- a/Assets/UI/Scripts/Main/QuitGame.gd
+++ b/Assets/UI/Scripts/Main/QuitGame.gd
@@ -1,7 +1,7 @@
 extends BaseButton
 
-var scene = load("res://Assets/UI/Scenes/MainMenuScene.tscn") # : PackedScene
+var _scene = preload("res://Assets/UI/Scenes/MainMenuScene.tscn") # : PackedScene
 
 func _pressed():
-	var _stfu = get_tree().change_scene_to(scene)
-	pass
+	#warning-ignore:return_value_discarded
+	get_tree().change_scene_to(_scene)

--- a/Assets/UI/Scripts/Main/ResumeGame.gd
+++ b/Assets/UI/Scripts/Main/ResumeGame.gd
@@ -1,5 +1,7 @@
 extends BaseButton
 
+var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
+
 func _pressed():
-	var _stfu = get_tree().change_scene("res://Assets/World/World.tscn")
-	pass
+	#warning-ignore:return_value_discarded
+	get_tree().change_scene_to(_scene)


### PR DESCRIPTION
- Use `preload` instead of `load`.
- Remove unnecessary `pass`es.
- Make correct use of "_" in the beginning of variables.