### PR TITLE
Change main menu scene to have a singular script

### DIFF
--- a/Assets/UI/Scenes/ExitScene.tscn
+++ b/Assets/UI/Scenes/ExitScene.tscn
@@ -3,53 +3,121 @@
 [ext_resource path="res://Assets/UI/Scripts/ExitScene.gd" type="Script" id=1]
 [ext_resource path="res://Assets/UI/Themes/HUDTheme.tres" type="Theme" id=2]
 
-[node name="ExitScene" type="Node"]
+[node name="ExitScene" type="Node" index="0"]
+
 script = ExtResource( 1 )
 
-[node name="CenterContainer" type="CenterContainer" parent="."]
+[node name="CenterContainer" type="CenterContainer" parent="." index="0"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_right = 40.0
 margin_bottom = 40.0
 rect_min_size = Vector2( 1600, 900 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 0
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 2 )
+use_top_left = false
 
-[node name="PanelContainer" type="PanelContainer" parent="CenterContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="CenterContainer" index="0"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_left = 583.0
 margin_top = 400.0
 margin_right = 1017.0
 margin_bottom = 500.0
 rect_min_size = Vector2( 100, 100 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/PanelContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="CenterContainer/PanelContainer" index="0"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_right = 434.0
 margin_bottom = 100.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+alignment = 0
 
-[node name="VSeparator" type="VSeparator" parent="CenterContainer/PanelContainer/HBoxContainer"]
+[node name="VSeparator" type="VSeparator" parent="CenterContainer/PanelContainer/HBoxContainer" index="0"]
+
 modulate = Color( 1, 1, 1, 0 )
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_top = 40.0
 margin_right = 20.0
 margin_bottom = 60.0
 rect_min_size = Vector2( 20, 20 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
 size_flags_vertical = 6
 
-[node name="Label" type="Label" parent="CenterContainer/PanelContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="CenterContainer/PanelContainer/HBoxContainer" index="1"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_left = 24.0
 margin_top = 31.0
 margin_right = 410.0
 margin_bottom = 68.0
 rect_min_size = Vector2( 20, 20 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 2
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
 size_flags_vertical = 6
 text = "Game is exiting, please wait..."
 align = 1
 valign = 1
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
 
-[node name="VSeparator2" type="VSeparator" parent="CenterContainer/PanelContainer/HBoxContainer"]
+[node name="VSeparator2" type="VSeparator" parent="CenterContainer/PanelContainer/HBoxContainer" index="2"]
+
 modulate = Color( 1, 1, 1, 0 )
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_left = 414.0
 margin_top = 40.0
 margin_right = 434.0
 margin_bottom = 60.0
 rect_min_size = Vector2( 20, 20 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
 size_flags_vertical = 6
+
 

--- a/Assets/UI/Scenes/MainMenuScene.tscn
+++ b/Assets/UI/Scenes/MainMenuScene.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://Assets/UI/Images/Background/MainMenu/bg_1.png" type="Texture" id=1]
 [ext_resource path="res://Assets/UI/Scenes/MainMenuUI.tscn" type="PackedScene" id=2]
 
-[node name="MainMenuScene" type="Node"]
+[node name="MainMenuScene" type="Node" index="0"]
 
 [node name="TextureRect" type="TextureRect" parent="." index="0"]
 

--- a/Assets/UI/Scenes/MainMenuUI.tscn
+++ b/Assets/UI/Scenes/MainMenuUI.tscn
@@ -1,28 +1,21 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://Assets/UI/Themes/MenuTheme.tres" type="Theme" id=1]
-[ext_resource path="res://Assets/UI/Images/Background/MainMenu/wheel.png" type="Texture" id=2]
-[ext_resource path="res://Assets/UI/Images/Buttons/msg_button.png" type="Texture" id=3]
-[ext_resource path="res://Assets/UI/Images/Buttons/msg_button_h.png" type="Texture" id=4]
-[ext_resource path="res://Assets/UI/Images/Buttons/msg_button_bw.png" type="Texture" id=5]
-[ext_resource path="res://Assets/UI/Scripts/Main/NewGame.gd" type="Script" id=6]
+[ext_resource path="res://Assets/UI/Scripts/Main/MainMenuUI.gd" type="Script" id=2]
+[ext_resource path="res://Assets/UI/Images/Background/MainMenu/wheel.png" type="Texture" id=3]
+[ext_resource path="res://Assets/UI/Images/Buttons/msg_button.png" type="Texture" id=4]
+[ext_resource path="res://Assets/UI/Images/Buttons/msg_button_h.png" type="Texture" id=5]
+[ext_resource path="res://Assets/UI/Images/Buttons/msg_button_bw.png" type="Texture" id=6]
 [ext_resource path="res://Assets/UI/Icons/MainMenu/compass_bw.png" type="Texture" id=7]
-[ext_resource path="res://Assets/UI/Scripts/Main/LoadGame.gd" type="Script" id=8]
-[ext_resource path="res://Assets/UI/Icons/MainMenu/load_bw.png" type="Texture" id=9]
-[ext_resource path="res://Assets/UI/Scripts/Main/LogButton.gd" type="Script" id=10]
-[ext_resource path="res://Assets/UI/Icons/MainMenu/log_bw.png" type="Texture" id=11]
-[ext_resource path="res://Assets/UI/Scripts/Main/EditorButton.gd" type="Script" id=12]
-[ext_resource path="res://Assets/UI/Icons/MainMenu/editor_bw.png" type="Texture" id=13]
-[ext_resource path="res://Assets/UI/Scripts/Main/ExitGame.gd" type="Script" id=14]
-[ext_resource path="res://Assets/UI/Icons/MainMenu/door_bw.png" type="Texture" id=15]
-[ext_resource path="res://Assets/UI/Scripts/Main/HelpButton.gd" type="Script" id=16]
-[ext_resource path="res://Assets/UI/Icons/MainMenu/help_bw.png" type="Texture" id=17]
-[ext_resource path="res://Assets/UI/Scripts/Main/Options.gd" type="Script" id=18]
-[ext_resource path="res://Assets/UI/Icons/MainMenu/gears_bw.png" type="Texture" id=19]
-[ext_resource path="res://Assets/UI/Scripts/Main/Connect.gd" type="Script" id=20]
-[ext_resource path="res://Assets/UI/Icons/MainMenu/multiplayer_bw.png" type="Texture" id=21]
+[ext_resource path="res://Assets/UI/Icons/MainMenu/load_bw.png" type="Texture" id=8]
+[ext_resource path="res://Assets/UI/Icons/MainMenu/log_bw.png" type="Texture" id=9]
+[ext_resource path="res://Assets/UI/Icons/MainMenu/editor_bw.png" type="Texture" id=10]
+[ext_resource path="res://Assets/UI/Icons/MainMenu/door_bw.png" type="Texture" id=11]
+[ext_resource path="res://Assets/UI/Icons/MainMenu/help_bw.png" type="Texture" id=12]
+[ext_resource path="res://Assets/UI/Icons/MainMenu/gears_bw.png" type="Texture" id=13]
+[ext_resource path="res://Assets/UI/Icons/MainMenu/multiplayer_bw.png" type="Texture" id=14]
 
-[node name="MainMenuUI" type="HBoxContainer"]
+[node name="MainMenuUI" type="HBoxContainer" index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -42,6 +35,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 1 )
 alignment = 1
+script = ExtResource( 2 )
 
 [node name="MenuItems" type="CenterContainer" parent="." index="0"]
 
@@ -79,7 +73,7 @@ mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
 theme = ExtResource( 1 )
-texture = ExtResource( 2 )
+texture = ExtResource( 3 )
 stretch_mode = 0
 _sections_unfolded = [ "Rect" ]
 
@@ -110,12 +104,14 @@ toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
 group = null
-texture_normal = ExtResource( 3 )
-texture_pressed = ExtResource( 4 )
-texture_hover = ExtResource( 4 )
-texture_disabled = ExtResource( 5 )
-texture_focused = ExtResource( 4 )
-script = ExtResource( 6 )
+texture_normal = ExtResource( 4 )
+texture_pressed = ExtResource( 5 )
+texture_hover = ExtResource( 5 )
+texture_disabled = ExtResource( 6 )
+texture_focused = ExtResource( 5 )
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="TextureRect" type="TextureRect" parent="MenuItems/Buttons/NewGameButton" index="0"]
 
@@ -137,9 +133,6 @@ size_flags_vertical = 1
 texture = ExtResource( 7 )
 stretch_mode = 0
 _sections_unfolded = [ "Anchor", "Margin", "Rect" ]
-__meta__ = {
-"_edit_lock_": true
-}
 
 [node name="LoadGameButton" type="TextureButton" parent="MenuItems/Buttons" index="1"]
 
@@ -168,13 +161,15 @@ toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
 group = null
-texture_normal = ExtResource( 3 )
-texture_pressed = ExtResource( 4 )
-texture_hover = ExtResource( 4 )
-texture_disabled = ExtResource( 5 )
-texture_focused = ExtResource( 4 )
-script = ExtResource( 8 )
+texture_normal = ExtResource( 4 )
+texture_pressed = ExtResource( 5 )
+texture_hover = ExtResource( 5 )
+texture_disabled = ExtResource( 6 )
+texture_focused = ExtResource( 5 )
 _sections_unfolded = [ "Margin", "Rect" ]
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="TextureRect" type="TextureRect" parent="MenuItems/Buttons/LoadGameButton" index="0"]
 
@@ -193,12 +188,9 @@ mouse_filter = 2
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
-texture = ExtResource( 9 )
+texture = ExtResource( 8 )
 stretch_mode = 0
 _sections_unfolded = [ "Anchor", "Margin", "Rect" ]
-__meta__ = {
-"_edit_lock_": true
-}
 
 [node name="LogButton" type="TextureButton" parent="MenuItems/Buttons" index="2"]
 
@@ -227,13 +219,15 @@ toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
 group = null
-texture_normal = ExtResource( 3 )
-texture_pressed = ExtResource( 4 )
-texture_hover = ExtResource( 4 )
-texture_disabled = ExtResource( 5 )
-texture_focused = ExtResource( 4 )
-script = ExtResource( 10 )
+texture_normal = ExtResource( 4 )
+texture_pressed = ExtResource( 5 )
+texture_hover = ExtResource( 5 )
+texture_disabled = ExtResource( 6 )
+texture_focused = ExtResource( 5 )
 _sections_unfolded = [ "Margin", "Rect" ]
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="TextureRect" type="TextureRect" parent="MenuItems/Buttons/LogButton" index="0"]
 
@@ -252,12 +246,9 @@ mouse_filter = 2
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
-texture = ExtResource( 11 )
+texture = ExtResource( 9 )
 stretch_mode = 0
 _sections_unfolded = [ "Anchor", "Margin", "Rect" ]
-__meta__ = {
-"_edit_lock_": true
-}
 
 [node name="EditorButton" type="TextureButton" parent="MenuItems/Buttons" index="3"]
 
@@ -286,13 +277,15 @@ toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
 group = null
-texture_normal = ExtResource( 3 )
-texture_pressed = ExtResource( 4 )
-texture_hover = ExtResource( 4 )
-texture_disabled = ExtResource( 5 )
-texture_focused = ExtResource( 4 )
-script = ExtResource( 12 )
+texture_normal = ExtResource( 4 )
+texture_pressed = ExtResource( 5 )
+texture_hover = ExtResource( 5 )
+texture_disabled = ExtResource( 6 )
+texture_focused = ExtResource( 5 )
 _sections_unfolded = [ "Margin", "Rect" ]
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="TextureRect" type="TextureRect" parent="MenuItems/Buttons/EditorButton" index="0"]
 
@@ -311,12 +304,9 @@ mouse_filter = 2
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
-texture = ExtResource( 13 )
+texture = ExtResource( 10 )
 stretch_mode = 0
 _sections_unfolded = [ "Anchor", "Margin", "Rect" ]
-__meta__ = {
-"_edit_lock_": true
-}
 
 [node name="ExitGameButton" type="TextureButton" parent="MenuItems/Buttons" index="4"]
 
@@ -345,13 +335,15 @@ toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
 group = null
-texture_normal = ExtResource( 3 )
-texture_pressed = ExtResource( 4 )
-texture_hover = ExtResource( 4 )
-texture_disabled = ExtResource( 5 )
-texture_focused = ExtResource( 4 )
-script = ExtResource( 14 )
+texture_normal = ExtResource( 4 )
+texture_pressed = ExtResource( 5 )
+texture_hover = ExtResource( 5 )
+texture_disabled = ExtResource( 6 )
+texture_focused = ExtResource( 5 )
 _sections_unfolded = [ "Margin", "Rect" ]
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="TextureRect" type="TextureRect" parent="MenuItems/Buttons/ExitGameButton" index="0"]
 
@@ -370,12 +362,9 @@ mouse_filter = 2
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
-texture = ExtResource( 15 )
+texture = ExtResource( 11 )
 stretch_mode = 0
 _sections_unfolded = [ "Anchor", "Margin", "Rect" ]
-__meta__ = {
-"_edit_lock_": true
-}
 
 [node name="HelpButton" type="TextureButton" parent="MenuItems/Buttons" index="5"]
 
@@ -404,13 +393,15 @@ toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
 group = null
-texture_normal = ExtResource( 3 )
-texture_pressed = ExtResource( 4 )
-texture_hover = ExtResource( 4 )
-texture_disabled = ExtResource( 5 )
-texture_focused = ExtResource( 4 )
-script = ExtResource( 16 )
+texture_normal = ExtResource( 4 )
+texture_pressed = ExtResource( 5 )
+texture_hover = ExtResource( 5 )
+texture_disabled = ExtResource( 6 )
+texture_focused = ExtResource( 5 )
 _sections_unfolded = [ "Margin", "Rect" ]
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="TextureRect" type="TextureRect" parent="MenuItems/Buttons/HelpButton" index="0"]
 
@@ -429,12 +420,9 @@ mouse_filter = 2
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
-texture = ExtResource( 17 )
+texture = ExtResource( 12 )
 stretch_mode = 0
 _sections_unfolded = [ "Anchor", "Margin", "Rect" ]
-__meta__ = {
-"_edit_lock_": true
-}
 
 [node name="OptionsButton" type="TextureButton" parent="MenuItems/Buttons" index="6"]
 
@@ -463,13 +451,15 @@ toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
 group = null
-texture_normal = ExtResource( 3 )
-texture_pressed = ExtResource( 4 )
-texture_hover = ExtResource( 4 )
-texture_disabled = ExtResource( 5 )
-texture_focused = ExtResource( 4 )
-script = ExtResource( 18 )
+texture_normal = ExtResource( 4 )
+texture_pressed = ExtResource( 5 )
+texture_hover = ExtResource( 5 )
+texture_disabled = ExtResource( 6 )
+texture_focused = ExtResource( 5 )
 _sections_unfolded = [ "Margin", "Rect" ]
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="TextureRect" type="TextureRect" parent="MenuItems/Buttons/OptionsButton" index="0"]
 
@@ -488,12 +478,9 @@ mouse_filter = 2
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
-texture = ExtResource( 19 )
+texture = ExtResource( 13 )
 stretch_mode = 0
 _sections_unfolded = [ "Anchor", "Margin", "Rect" ]
-__meta__ = {
-"_edit_lock_": true
-}
 
 [node name="ConnectButton" type="TextureButton" parent="MenuItems/Buttons" index="7"]
 
@@ -522,13 +509,15 @@ toggle_mode = false
 enabled_focus_mode = 2
 shortcut = null
 group = null
-texture_normal = ExtResource( 3 )
-texture_pressed = ExtResource( 4 )
-texture_hover = ExtResource( 4 )
-texture_disabled = ExtResource( 5 )
-texture_focused = ExtResource( 4 )
-script = ExtResource( 20 )
+texture_normal = ExtResource( 4 )
+texture_pressed = ExtResource( 5 )
+texture_hover = ExtResource( 5 )
+texture_disabled = ExtResource( 6 )
+texture_focused = ExtResource( 5 )
 _sections_unfolded = [ "Margin", "Rect" ]
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="TextureRect" type="TextureRect" parent="MenuItems/Buttons/ConnectButton" index="0"]
 
@@ -547,11 +536,14 @@ mouse_filter = 2
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
-texture = ExtResource( 21 )
+texture = ExtResource( 14 )
 stretch_mode = 0
 _sections_unfolded = [ "Anchor", "Margin", "Rect" ]
-__meta__ = {
-"_edit_lock_": true
-}
+
+[connection signal="pressed" from="MenuItems/Buttons/NewGameButton" to="." method="_go_to_scene" binds= [ "world" ]]
+
+[connection signal="pressed" from="MenuItems/Buttons/LoadGameButton" to="." method="_go_to_scene" binds= [ "world" ]]
+
+[connection signal="pressed" from="MenuItems/Buttons/ExitGameButton" to="." method="_go_to_scene" binds= [ "exit" ]]
 
 

--- a/Assets/UI/Scenes/OptionsMenu.tscn
+++ b/Assets/UI/Scenes/OptionsMenu.tscn
@@ -4,47 +4,117 @@
 [ext_resource path="res://Assets/UI/Scripts/Main/QuitGame.gd" type="Script" id=2]
 
 [node name="OptionsMenu" type="HBoxContainer"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_right = 1600.0
 margin_bottom = 124.0
 rect_min_size = Vector2( 1600, 900 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
 alignment = 1
 
-[node name="Buttons" type="VBoxContainer" parent="."]
+[node name="Buttons" type="VBoxContainer" parent="." index="0"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_left = 650.0
 margin_right = 950.0
 margin_bottom = 900.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
 alignment = 1
 
-[node name="Button" type="Button" parent="Buttons"]
+[node name="Button" type="Button" parent="Buttons" index="0"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_top = 371.0
 margin_right = 300.0
 margin_bottom = 431.0
 rect_min_size = Vector2( 300, 60 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
 focus_neighbour_left = NodePath(".")
 focus_neighbour_top = NodePath(".")
 focus_neighbour_right = NodePath(".")
 focus_neighbour_bottom = NodePath("../LoadGameButton")
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
 theme = ExtResource( 1 )
+toggle_mode = false
+enabled_focus_mode = 2
+shortcut = null
+group = null
 text = "TODO"
+flat = false
+align = 1
 
-[node name="HSeparator" type="HSeparator" parent="Buttons"]
+[node name="HSeparator" type="HSeparator" parent="Buttons" index="1"]
+
 modulate = Color( 1, 1, 1, 0 )
 self_modulate = Color( 1, 1, 1, 0 )
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_top = 435.0
 margin_right = 300.0
 margin_bottom = 465.0
 rect_min_size = Vector2( 300, 30 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
 
-[node name="AcceptButton" type="Button" parent="Buttons"]
+[node name="AcceptButton" type="Button" parent="Buttons" index="2"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
 margin_top = 469.0
 margin_right = 300.0
 margin_bottom = 529.0
 rect_min_size = Vector2( 300, 60 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
 focus_neighbour_left = NodePath(".")
 focus_neighbour_top = NodePath(".")
 focus_neighbour_right = NodePath(".")
 focus_neighbour_bottom = NodePath("../LoadGameButton")
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
 theme = ExtResource( 1 )
+toggle_mode = false
+enabled_focus_mode = 2
+shortcut = null
+group = null
 text = "Accept"
+flat = false
+align = 1
 script = ExtResource( 2 )
+
 

--- a/Assets/UI/Scripts/Main/CloseMenu.gd
+++ b/Assets/UI/Scripts/Main/CloseMenu.gd
@@ -1,4 +1,4 @@
-extends BaseButton
+extends Button
 
 var _parent # : VBoxContainer
 

--- a/Assets/UI/Scripts/Main/Connect.gd
+++ b/Assets/UI/Scripts/Main/Connect.gd
@@ -1,8 +1,0 @@
-extends BaseButton
-
-#var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
-
-func _pressed():
-	#warning-ignore:return_value_discarded
-	#get_tree().change_scene_to(_scene)
-	pass

--- a/Assets/UI/Scripts/Main/EditorButton.gd
+++ b/Assets/UI/Scripts/Main/EditorButton.gd
@@ -1,8 +1,0 @@
-extends BaseButton
-
-#var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
-
-func _pressed():
-	#warning-ignore:return_value_discarded
-	#get_tree().change_scene_to(_scene)
-	pass

--- a/Assets/UI/Scripts/Main/ExitGame.gd
+++ b/Assets/UI/Scripts/Main/ExitGame.gd
@@ -1,7 +1,0 @@
-extends BaseButton
-
-var _scene = preload("res://Assets/UI/Scenes/ExitScene.tscn") # : PackedScene
-
-func _pressed():
-	#warning-ignore:return_value_discarded
-	get_tree().change_scene_to(_scene)

--- a/Assets/UI/Scripts/Main/HelpButton.gd
+++ b/Assets/UI/Scripts/Main/HelpButton.gd
@@ -1,8 +1,0 @@
-extends BaseButton
-
-#var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
-
-func _pressed():
-	#warning-ignore:return_value_discarded
-	#get_tree().change_scene_to(_scene)
-	pass

--- a/Assets/UI/Scripts/Main/LoadGame.gd
+++ b/Assets/UI/Scripts/Main/LoadGame.gd
@@ -1,7 +1,0 @@
-extends BaseButton
-
-var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
-
-func _pressed():
-	#warning-ignore:return_value_discarded
-	get_tree().change_scene_to(_scene)

--- a/Assets/UI/Scripts/Main/LogButton.gd
+++ b/Assets/UI/Scripts/Main/LogButton.gd
@@ -1,8 +1,0 @@
-extends BaseButton
-
-#var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
-
-func _pressed():
-	#warning-ignore:return_value_discarded
-	#get_tree().change_scene_to(_scene)
-	pass

--- a/Assets/UI/Scripts/Main/MainMenuUI.gd
+++ b/Assets/UI/Scripts/Main/MainMenuUI.gd
@@ -1,0 +1,9 @@
+extends HBoxContainer
+
+const _scenes = {
+	world = preload("res://Assets/World/World.tscn"),
+	exit = preload("res://Assets/UI/Scenes/ExitScene.tscn")
+}
+
+func _go_to_scene(scene):
+	get_tree().change_scene_to(_scenes[scene])

--- a/Assets/UI/Scripts/Main/NewGame.gd
+++ b/Assets/UI/Scripts/Main/NewGame.gd
@@ -1,7 +1,0 @@
-extends BaseButton
-
-var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
-
-func _pressed():
-	#warning-ignore:return_value_discarded
-	get_tree().change_scene_to(_scene)

--- a/Assets/UI/Scripts/Main/Options.gd
+++ b/Assets/UI/Scripts/Main/Options.gd
@@ -1,8 +1,0 @@
-extends BaseButton
-
-#var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
-
-func _pressed():
-	#warning-ignore:return_value_discarded
-	#get_tree().change_scene_to(_scene)
-	pass

--- a/Assets/UI/Scripts/Main/QuitGame.gd
+++ b/Assets/UI/Scripts/Main/QuitGame.gd
@@ -1,4 +1,4 @@
-extends BaseButton
+extends Button
 
 var _scene = preload("res://Assets/UI/Scenes/MainMenuScene.tscn") # : PackedScene
 

--- a/Assets/UI/Scripts/Main/ResumeGame.gd
+++ b/Assets/UI/Scripts/Main/ResumeGame.gd
@@ -1,7 +1,0 @@
-extends BaseButton
-
-var _scene = preload("res://Assets/World/World.tscn") # : PackedScene
-
-func _pressed():
-	#warning-ignore:return_value_discarded
-	get_tree().change_scene_to(_scene)


### PR DESCRIPTION
This changes so the main menu only has a single script, which its buttons are connected to, telling it which scene they will open.

@LinuxDonald, this is generally how it's done on most Godot projects, as it's far more manageable than hopping around smaller scripts doing very small tasks.