### PR TITLE
Add 'width' and 'height' attributes to logo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="http://unknown-horizons.org/"><img src="http://unknown-horizons.org/static/logo.svg" alt="Unknown Horizons"></a></p>
+<p align="center"><a href="http://unknown-horizons.org/"><img src="http://unknown-horizons.org/static/logo.svg" alt="Unknown Horizons" width="278" height="326"></a></p>
 
 **We are searching for developers for our [Godot Engine](https://godotengine.org/) port**.
 We want to port it because our current engine is basically dead.


### PR DESCRIPTION
This allocates space for the image while it loads, so the text doesn't just slides down out of nowhere.

This should be my last commit fiddling with it.