### PR TITLE
Small project and audio bus changes

### DIFF
--- a/Assets/Audio/Music/GameMusic.gd
+++ b/Assets/Audio/Music/GameMusic.gd
@@ -3,16 +3,16 @@ extends AudioStreamPlayer
 # If this script somehow fails, "lose.ogg" will be played.
 
 var current_music
-# Above could possibly be displayed inside a music player / list GUI
+# Above could possibly be displayed inside a music player/list GUI.
 var _music_files = []
-var _music_streams = [] # Note: Does not show up in remote inspector
+var _music_streams = [] # Note: Does not show up in remote inspector.
 
 func _ready():
 	var dir = Directory.new()
 	dir.open("res://Assets/Audio/Music/Ambient")
 	dir.list_dir_begin()
 	
-	# Load all the files from the Ambient folder
+	# Load all the files from the Ambient folder.
 	while true:
 		var file = dir.get_next()
 		if file == "":
@@ -24,40 +24,36 @@ func _ready():
 		var stream = load("Assets/Audio/Music/Ambient/" + filename)
 		_music_streams.append(stream)
 	
-	# Always play a specific song when the game starts
-	stream = load("res://Assets/Audio/Music/Ambient/newfrontier.ogg")
+	# Always play a specific song when the game starts.
+	stream = preload("res://Assets/Audio/Music/Ambient/newfrontier.ogg")
 	play()
 	#play_song_random()
-	pass
 
 func _on_GameMusic_finished():
 	play_song_random()
-	pass
 
 func play_song_random():
-	randomize() # Godot will always generate the same random numbers otherwise
+	randomize() # Godot will always generate the same random numbers otherwise.
 	var size = _music_streams.size()
 	var rand = randi() % size
 	play_song_index(rand)
-	pass
 
 func play_song_index(index):
 	stop()
 	stream = _music_streams[index]
 	current_music = _music_files[index]
 	play()
-	pass
 
-# All the functions below are untested
-func add_song(filename):
-	_music_files.append(filename)
-	_music_streams.append(load("res://Assets/Audio/Music/Ambient/" + filename))
-	pass
+# All the functions below are untested.
 
-func remove_song(filename):
-	var i = _music_files.find(filename)
+func add_song(file_name):
+	_music_files.append(file_name)
+	_music_streams.append(
+			load("res://Assets/Audio/Music/Ambient/" + file_name))
+
+func remove_song(file_name):
+	var i = _music_files.find(file_name)
 	remove_song_index(i)
-	pass
 
 func remove_song_index(index):
 	_music_streams.remove(index)

--- a/Assets/UI/Scenes/MainMenuScene.tscn
+++ b/Assets/UI/Scenes/MainMenuScene.tscn
@@ -32,6 +32,6 @@ volume_db = -20.0
 pitch_scale = 1.0
 autoplay = true
 mix_target = 0
-bus = "Master"
+bus = "Music"
 
 

--- a/Assets/UI/Scenes/MainMenuUI.tscn
+++ b/Assets/UI/Scenes/MainMenuUI.tscn
@@ -15,7 +15,7 @@
 [ext_resource path="res://Assets/UI/Icons/MainMenu/gears_bw.png" type="Texture" id=13]
 [ext_resource path="res://Assets/UI/Icons/MainMenu/multiplayer_bw.png" type="Texture" id=14]
 
-[node name="MainMenuUI" type="Control" index="0"]
+[node name="MainMenuUI" type="Control"]
 
 anchor_left = 0.0
 anchor_top = 0.0

--- a/Assets/World/World.tscn
+++ b/Assets/World/World.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://Assets/Audio/Sounds/Events/Scenario/lose.ogg" type="AudioStream" id=1]
 [ext_resource path="res://Assets/Audio/Music/GameMusic.gd" type="Script" id=2]
 
-[node name="World" type="Node2D"]
+[node name="World" type="Node2D" index="0"]
 
 [node name="GameMusic" type="AudioStreamPlayer" parent="." index="0"]
 
@@ -12,7 +12,7 @@ volume_db = -20.0
 pitch_scale = 1.0
 autoplay = true
 mix_target = 0
-bus = "Master"
+bus = "Music"
 script = ExtResource( 2 )
 
 [connection signal="finished" from="GameMusic" to="GameMusic" method="_on_GameMusic_finished"]

--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -1,0 +1,23 @@
+[gd_resource type="AudioBusLayout" format=2]
+
+[resource]
+
+bus/0/name = "Master"
+bus/0/solo = false
+bus/0/mute = false
+bus/0/bypass_fx = false
+bus/0/volume_db = 0.0
+bus/0/send = ""
+bus/1/name = "Music"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/bypass_fx = false
+bus/1/volume_db = 0.0
+bus/1/send = "Master"
+bus/2/name = "Effects"
+bus/2/solo = false
+bus/2/mute = false
+bus/2/bypass_fx = false
+bus/2/volume_db = 0.0
+bus/2/send = "Master"
+

--- a/project.godot
+++ b/project.godot
@@ -10,7 +10,7 @@ config_version=3
 
 [application]
 
-config/name="UnknownHorizons"
+config/name="Unknown Horizons"
 run/main_scene="res://Assets/UI/Scenes/MainMenuScene.tscn"
 config/icon="res://icon.png"
 
@@ -18,14 +18,15 @@ config/icon="res://icon.png"
 
 PersistentEnv="*res://Assets/World/PersistentEnv.tscn"
 
-[debug]
-
-settings/stdout/print_fps=true
-
 [display]
 
 window/size/width=1600
 window/size/height=900
+
+[logging]
+
+file_logging/enable_file_logging=true
+file_logging/max_log_files=5
 
 [rendering]
 


### PR DESCRIPTION
- Enable log file creation.
- Disable FPS printing. FPS can be analysed via the debugger, without having to spam the output tab.
- Add "Music" and "Effects" audio buses, and made the the music streamer nodes use the "Music" bus.
- Corrections in the music stream script in World scene.