### PR TITLE
Easier GUI setup in the editor and typo fix

### DIFF
--- a/Assets/UI/Scenes/MainMenuUI.tscn
+++ b/Assets/UI/Scenes/MainMenuUI.tscn
@@ -146,6 +146,9 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource( 1 )
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_lock_": true
+}
 
 [node name="Decoration" type="TextureRect" parent="."]
 anchor_left = 0.5
@@ -171,7 +174,7 @@ margin_left = -50.0
 margin_top = -205.0
 margin_right = 50.0
 margin_bottom = -105.0
-allignement = "top"
+alignment = "top"
 text = "Single Player"
 texture = ExtResource( 5 )
 
@@ -204,7 +207,7 @@ margin_left = -50.0
 margin_top = 105.0
 margin_right = 50.0
 margin_bottom = 205.0
-allignement = "bottom"
+alignment = "bottom"
 text = "Quit"
 texture = ExtResource( 9 )
 
@@ -213,7 +216,7 @@ margin_left = 61.0
 margin_top = 57.0
 margin_right = 161.0
 margin_bottom = 157.0
-allignement = "right"
+alignment = "right"
 text = "Help"
 
 [node name="OptionsButton" parent="Decoration/MenuItems" instance=ExtResource( 4 )]
@@ -221,7 +224,7 @@ margin_left = 105.0
 margin_top = -50.0
 margin_right = 205.0
 margin_bottom = 50.0
-allignement = "right"
+alignment = "right"
 text = "Options"
 texture = ExtResource( 10 )
 
@@ -230,7 +233,7 @@ margin_left = 60.0
 margin_top = -160.0
 margin_right = 160.0
 margin_bottom = -60.0
-allignement = "right"
+alignment = "right"
 text = "Connect"
 texture = ExtResource( 11 )
 

--- a/Assets/UI/Scripts/Main/MainMenuButton.gd
+++ b/Assets/UI/Scripts/Main/MainMenuButton.gd
@@ -1,12 +1,11 @@
 tool
 extends TextureButton
 
-export var allignement := "left"
-export var text := ""
-export var texture: Texture =\
-		preload("res://Assets/UI/Icons/MainMenu/help_bw.png") # Fallback.
+export(String, "left", "right", "top", "bottom") var alignment := "left" setget set_alignment
+export var text := "" setget set_text
+export var texture: Texture = preload("res://Assets/UI/Icons/MainMenu/help_bw.png") setget set_texture # Fallback
 
-var allignements = {
+var alignments = {
 	left = Vector2(-200, 30),
 	right = Vector2(100, 30),
 	top = Vector2(-50, -35),
@@ -14,6 +13,18 @@ var allignements = {
 }
 
 func _ready() -> void:
-	$Panel.rect_position = allignements[allignement]
+	$Panel.rect_position = alignments[alignment]
 	$Panel/Label.text = text
+	$Icon.texture = texture
+
+func set_alignment(new_alignment):
+	alignment = new_alignment
+	$Panel.rect_position = alignments[alignment]
+
+func set_text(new_text):
+	text = new_text
+	$Panel/Label.text = text
+
+func set_texture(new_texture):
+	texture = new_texture
 	$Icon.texture = texture

--- a/Assets/World/Buildings/Citizens/Residential/Residence.gd
+++ b/Assets/World/Buildings/Citizens/Residential/Residence.gd
@@ -1,3 +1,4 @@
+tool
 extends Building
 class_name Residence
 

--- a/Assets/World/Buildings/Citizens/Residential/Residence.tscn
+++ b/Assets/World/Buildings/Citizens/Residential/Residence.tscn
@@ -3,6 +3,5 @@
 [ext_resource path="res://Assets/World/Buildings/Building.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Assets/World/Buildings/Citizens/Residential/Residence.gd" type="Script" id=2]
 
-[node name="Residence" instance=ExtResource( 1 )]
+[node name="Residence" index="0" instance=ExtResource( 1 )]
 script = ExtResource( 2 )
-


### PR DESCRIPTION
To get started, I fixed typos ("allignements") and added setget methods to the GUI export variables to make them take use of Godot's tool feature and have instant feedback on GUI adjustments (instead of having to reload the scene). Also changed the alignment export var from text to a combo box for obviously better usability.
Beside that, made the residences visible within the editor to have a synced up view to the actual game.

This is my first PR.