### PR TITLE
Reimplement unit movement mechanic as interaction state

### DIFF
--- a/Assets/Player/InteractionContext.gd
+++ b/Assets/Player/InteractionContext.gd
@@ -46,7 +46,7 @@ class_name InteractionContext
 signal switch_context
 signal abort_context
 
-onready var _parent := get_parent()
+onready var _player_camera := get_parent().get_parent()
 
 export(String) var _context_name = "Basic Interaction Context"
 export(PoolStringArray) var valid_actions = ["main_command"]
@@ -80,7 +80,7 @@ func _on_enter() -> void:
 	print_debug("InteractionContext %s entered" % _context_name)
 
 func _on_exit() -> void:
-	print_debug("InteractionContext %s left" % _context_name)
+	print_debug("InteractionContext %s exited" % _context_name)
 
 func _on_mouse_motion(event: InputEventMouseMotion, target: Node, position: Vector3) -> void:
 	pass

--- a/Assets/Player/InteractionContexts/MovementContext.gd
+++ b/Assets/Player/InteractionContexts/MovementContext.gd
@@ -1,0 +1,15 @@
+extends SelectionContext
+class_name MovementContext
+
+func move_selected_units(m_pos: Vector2) -> void:
+	var result = _player_camera.raycast_from_mouse(m_pos, 1)
+	if result:
+		#print_debug("Command: Move selected units {0}".format([result]))
+		for unit in _player_camera.selected_units:
+			unit.move_to(result.position)
+
+func _on_ia_main_command_pressed(target: Node, position: Vector3) -> void:
+	print_debug("Move action")
+
+	var m_pos = get_viewport().get_mouse_position()
+	move_selected_units(m_pos)

--- a/Assets/Player/InteractionContexts/SelectionContext.gd
+++ b/Assets/Player/InteractionContexts/SelectionContext.gd
@@ -1,38 +1,15 @@
 extends InteractionContext
+class_name SelectionContext
 
-signal set_selection
+signal selected
+signal deselected
+
+onready var _parent := get_parent()
 
 export(int) var selection_tolerance = 10
 
 var sel_pos_start: Vector3
 var sel_pos_end: Vector3
-
-func _on_ia_alt_command_pressed(target: Node, position: Vector3) -> void:
-	# Start selection
-	print_debug("Start selection")
-	sel_pos_start = position
-	_parent.set_sel_pos_start(position)
-	_parent.show()
-
-func _on_ia_alt_command_released(target: Node, position: Vector3) -> void:
-	# End selection
-	print_debug("End selection")
-	sel_pos_end = position
-	var selection: Array
-	var top_left: Vector2 = get_viewport().get_camera().unproject_position(sel_pos_start)
-	var bottom_right: Vector2 = get_viewport().get_camera().unproject_position(sel_pos_end)
-	if top_left.distance_to(bottom_right) <= selection_tolerance:
-		if target.is_in_group("units"):
-			selection = [target]
-	else:
-		selection = get_selected_units(top_left, bottom_right)
-	_parent.hide()
-	emit_signal("set_selection", selection)
-
-func _on_ia_main_command_pressed(target: Node, position: Vector3) -> void:
-	# Abort selection
-	print_debug("Abort selection")
-	_parent.hide()
 
 func get_selected_units(top_left: Vector2, bottom_right: Vector2) -> Array:
 	if top_left.x > bottom_right.x:
@@ -69,3 +46,34 @@ func get_selected_units(top_left: Vector2, bottom_right: Vector2) -> Array:
 #			print_debug("Unit [{0}]".format([unit]))
 #			box_selected_units.append(unit)
 #	return box_selected_units
+
+func _on_ia_alt_command_pressed(target: Node, position: Vector3) -> void:
+	# Start selection
+	print_debug("Start selection")
+	sel_pos_start = position
+	_parent.set_sel_pos_start(position)
+	_parent.show()
+
+func _on_ia_alt_command_released(target: Node, position: Vector3) -> void:
+	# End selection
+	print_debug("End selection")
+	sel_pos_end = position
+	var selection: Array
+	var top_left: Vector2 = get_viewport().get_camera().unproject_position(sel_pos_start)
+	var bottom_right: Vector2 = get_viewport().get_camera().unproject_position(sel_pos_end)
+	if top_left.distance_to(bottom_right) <= selection_tolerance:
+		if target.is_in_group("units"):
+			selection = [target]
+	else:
+		selection = get_selected_units(top_left, bottom_right)
+	_parent.hide()
+
+	if selection:
+		emit_signal("selected", selection)
+	else:
+		emit_signal("deselected")
+
+func _on_ia_main_command_pressed(target: Node, position: Vector3) -> void:
+	# Abort selection
+	print_debug("Abort selection")
+	_parent.hide()

--- a/Assets/Player/PlayerCamera.tscn
+++ b/Assets/Player/PlayerCamera.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://Assets/Player/PlayerCamera.gd" type="Script" id=1]
 [ext_resource path="res://Assets/UI/Scripts/SelectionBox.gd" type="Script" id=2]
 [ext_resource path="res://Assets/Player/PlayerHUD.tscn" type="PackedScene" id=3]
 [ext_resource path="res://Assets/Player/CameraControls.gd" type="Script" id=4]
 [ext_resource path="res://Assets/Player/InteractionContexts/SelectionContext.gd" type="Script" id=5]
+[ext_resource path="res://Assets/Player/InteractionContexts/MovementContext.gd" type="Script" id=6]
 
 [node name="PlayerCamera" type="Spatial"]
 pause_mode = 2
@@ -36,6 +37,11 @@ script = ExtResource( 5 )
 _context_name = "Selection"
 valid_actions = PoolStringArray( "main_command", "alt_command" )
 
+[node name="MovementContext" type="Node" parent="SelectionBox"]
+script = ExtResource( 6 )
+_context_name = "Movement"
+valid_actions = PoolStringArray( "main_command", "alt_command" )
+
 [node name="PlayerHUD" parent="." instance=ExtResource( 3 )]
 
 [node name="CameraControls" type="Node" parent="."]
@@ -43,4 +49,8 @@ script = ExtResource( 4 )
 origin_path = NodePath("..")
 camera_path = NodePath("../RotationY/Camera")
 rotation_y_path = NodePath("../RotationY")
-[connection signal="set_selection" from="SelectionBox/SelectionContext" to="." method="set_selection"]
+
+[connection signal="deselected" from="SelectionBox/SelectionContext" to="." method="unset_selection"]
+[connection signal="selected" from="SelectionBox/SelectionContext" to="." method="set_selection"]
+[connection signal="deselected" from="SelectionBox/MovementContext" to="." method="unset_selection"]
+[connection signal="selected" from="SelectionBox/MovementContext" to="." method="set_selection"]

--- a/project.godot
+++ b/project.godot
@@ -249,6 +249,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://Assets/UI/Scripts/MessageText.gd"
 }, {
+"base": "SelectionContext",
+"class": "MovementContext",
+"language": "GDScript",
+"path": "res://Assets/Player/InteractionContexts/MovementContext.gd"
+}, {
 "base": "BookMenu",
 "class": "NewGameUI",
 "language": "GDScript",
@@ -323,6 +328,11 @@ _global_script_classes=[ {
 "class": "School",
 "language": "GDScript",
 "path": "res://Assets/World/Buildings/Pioneers/School/School.gd"
+}, {
+"base": "InteractionContext",
+"class": "SelectionContext",
+"language": "GDScript",
+"path": "res://Assets/Player/InteractionContexts/SelectionContext.gd"
 }, {
 "base": "Unit",
 "class": "Ship",
@@ -493,6 +503,7 @@ _global_script_class_icons={
 "MainSquare": "",
 "MessageButton": "",
 "MessageText": "",
+"MovementContext": "",
 "NewGameUI": "",
 "OKButton": "",
 "OptionButtonEx": "",
@@ -508,6 +519,7 @@ _global_script_class_icons={
 "Residence": "",
 "SaltPonds": "",
 "School": "",
+"SelectionContext": "",
 "Ship": "",
 "ShipMenuTabWidget": "",
 "SignalFire": "",


### PR DESCRIPTION
Added `MovementContext` with slight adjustments in `PlayerCamera` and Interaction classes plus a bit of refactoring.

When a player controlled unit is selected, `PlayerCamera` now switches its interaction context from `SelectionContext` into `MovementContext` and the unit can be set in motion again.