### PR TITLE
Only let the player move their own troops

### DIFF
--- a/Assets/Player/InteractionContexts/MovementContext.gd
+++ b/Assets/Player/InteractionContexts/MovementContext.gd
@@ -6,7 +6,8 @@ func move_selected_units(m_pos: Vector2) -> void:
 	if result:
 		#print_debug("Command: Move selected units {0}".format([result]))
 		for unit in _player_camera.selected_units:
-			unit.move_to(result.position)
+			if unit.faction == _player_camera.player.faction:
+				unit.move_to(result.position)
 
 func _on_ia_main_command_pressed(target: Node, position: Vector3) -> void:
 	print_debug("Move action")


### PR DESCRIPTION
Edited the movement context so that only the players units can be given commands.

You can test it in the WorldTown scene: The pirate ship can be controlled by the player in the current version. With this edit, that's fixed.