### PR TITLE
Tweak map navigation and confine mouse within window boundaries

### DIFF
--- a/Assets/World/Global.gd
+++ b/Assets/World/Global.gd
@@ -409,6 +409,7 @@ func set_screen_resolution(screen_resolution: String) -> void:
 	resolution = Vector2(int(resolution[0]), int(resolution[1]))
 	OS.set_window_size(resolution)
 	OS.center_window()
+	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
 
 func set_audio_volumes() -> void:
 	Audio.set_master_volume(Config.master_volume)
@@ -445,9 +446,12 @@ func _input(event: InputEvent) -> void:
 
 		window_mode = (window_mode + 1) % WINDOW_MODES.size()
 		prints("window_mode:", window_mode)
+		Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)
 		OS.window_fullscreen = !OS.window_fullscreen
 
 		Config.window_mode = window_mode
+
+		Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
 
 	if event.is_action_pressed("quit_game"):
 		get_tree().quit()


### PR DESCRIPTION
Tweaked a number of `const` values and the methods regarding the map navigation in order to be more responsive. Also confined the mouse cursor within the window boundaries (window/fullscreen).
- Zoom mechanic
    - More reasonable range of zooming options
- `move()` (key-based camera panning)
    - Increased movement speed
    - Movement speed is also dependent on current zoom (`Camera.size`). The higher away from the map ground (the larger the "camera size"), the faster the camera moves
- `move_drag()` (mouse-based camera panning)
    - Increased movement speed