### PR TITLE
Removed errors caused by repeated connection to signals.

### DIFF
--- a/Assets/Player/InteractionContexts/TileContext.gd
+++ b/Assets/Player/InteractionContexts/TileContext.gd
@@ -18,6 +18,8 @@ var draw_path := []
 var aborted := false
 
 func _ready() -> void:
+	connect("tiles_changed", streets, "update_tiles")
+
 	set_process(false)
 
 func show_phantom_tile(tile_pos: Vector2) -> void:
@@ -50,8 +52,6 @@ func _on_enter() -> void:
 	phantom_tile.material_override = material
 	add_child(phantom_tile)
 	Input.set_custom_mouse_cursor(Cursor.CURSOR_TEAR, Input.CURSOR_ARROW)
-
-	connect("tiles_changed", streets, "update_tiles")
 
 	set_process(true)
 

--- a/Assets/UI/Scenes/TabWidgets/Switches/SwitchTabWidget.gd
+++ b/Assets/UI/Scenes/TabWidgets/Switches/SwitchTabWidget.gd
@@ -3,8 +3,6 @@ extends TextureButton
 class_name SwitchTabWidget
 # Base class for all widget switch handles.
 
-signal tab_changed(tab) # int
-
 export(Texture) var texture_active
 onready var _texture_normal := texture_normal
 
@@ -34,7 +32,9 @@ func get_tab_container() -> TabContainer:
 			tab_container = owner.body.get_node("TabContainer")
 
 			for switch in get_parent().get_children():
-				tab_container.connect("tab_changed", self, "_on_TabContainer_tab_changed")
+				switch.tab_container = tab_container
+				if !tab_container.is_connected("tab_changed", switch, "_on_TabContainer_tab_changed"):
+					tab_container.connect("tab_changed", switch, "_on_TabContainer_tab_changed")
 
 	return tab_container
 
@@ -45,7 +45,7 @@ func _on_SwitchTabWidget_pressed() -> void:
 	if self.tab_container:
 		prints("Set page", get_index(), "for", owner.name)
 		tab_container.current_tab = get_index()
-		emit_signal("tab_changed", tab_container.current_tab)
+		tab_container.emit_signal("tab_changed", tab_container.current_tab)
 
 #func _on_SwitchTabWidget_tab_changed(tab: int) -> void:
 #	if self.tab_container:


### PR DESCRIPTION
1. Selecting the road builder would cause an error after the first time. `connect: Signal 'tiles_changed' is already connected to given method 'update_tiles' in that object.`
This was because it tried to connect the stiles_changed signal ervery time. Thus i moved it to ready.
2. The signal wiring in the switch widgets was completly broken. It appears, the original author wanted to notify all SwitchTabWidgets every the tab changes. But insted, every first time a widget got selected, it tried to connect the same signal 5 time to itself, insted of to the other nodes. Therefore making the system not work and also throwing already connected errors. This is now fixed. I think it would make more sense though, to move the signal wiring and tabcontainer setting to the parent node. I kept the code in here, because it seems the original auther explicitly wanted to have it here.