### PR TITLE
Refactor global and related scripts

### DIFF
--- a/Assets/Player/Player.gd
+++ b/Assets/Player/Player.gd
@@ -11,7 +11,7 @@ var camera: PlayerCamera
 func _ready() -> void:
 	print_debug(
 		"I'm {0} in faction {1} ({2}).".format(
-				[Config.player_name, faction, Global.FACTIONS[faction]])
+				[Config.player_name, faction, Global.FACTIONS[faction].name])
 		)
 
 func _on_Game_notification(message_type: int, message_text: String) -> void:

--- a/Assets/Player/PlayerCamera.gd
+++ b/Assets/Player/PlayerCamera.gd
@@ -68,7 +68,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	active_context.interact(event, target_object, target_pos)
 
 func assign_to_player() -> Player:
-	return Global.Game.player if Global.Game != null and Global.Game.player else null
+	return Global.World.player if is_instance_valid(Global.World) and is_instance_valid(Global.World.player) else null
 
 func set_selection(new_selection: Array) -> void:
 	if new_selection.is_empty():

--- a/Assets/Player/PlayerHUD.gd
+++ b/Assets/Player/PlayerHUD.gd
@@ -144,13 +144,13 @@ func _on_PlayerCamera_selected(selected_entities: Array) -> void:
 			new_context = UIContext.TROOP
 			break
 		if entity is Ship:
-			if entity.faction == Global.Game.player.faction:
+			if entity.faction == Global.World.player.faction:
 				new_context = UIContext.SHIP
 			else:
 				new_context = UIContext.SHIP_FOREIGN
 
 			context_data = {
-				"FactionIndicator": Global.FACTION_FLAGS[entity.faction],
+				"FactionIndicator": Global.FACTIONS[entity.faction].emblem,
 				"Caption": entity.unit_name,
 			}
 

--- a/Assets/UI/TabWidgets/Buttons/MainButton/MainButtons/GameSpeedChangeButton.gd
+++ b/Assets/UI/TabWidgets/Buttons/MainButton/MainButtons/GameSpeedChangeButton.gd
@@ -6,4 +6,4 @@ class_name GameSpeedChangeButton
 func _pressed() -> void:
 	super()
 
-	Global.Game.set_game_speed(Engine.time_scale + game_speed_change)
+	Global.World.set_game_speed(Engine.time_scale + game_speed_change)

--- a/Assets/UI/TabWidgets/Buttons/MainButton/MainButtons/GameSpeedLabel.gd
+++ b/Assets/UI/TabWidgets/Buttons/MainButton/MainButtons/GameSpeedLabel.gd
@@ -6,10 +6,10 @@ func _ready() -> void:
 	if Engine.is_editor_hint:
 		return
 
-	call_deferred("connect_game") # waiting for Global.Game to be set
+	call_deferred("connect_game") # waiting for Global.World to be set
 
 func connect_game() -> void:
-	Global.Game.game_speed_changed.connect(_on_game_speed_changed)
+	Global.World.game_speed_changed.connect(_on_game_speed_changed)
 
 func _on_game_speed_changed(new_game_speed: float) -> void:
 	text = "%1.1fx" % new_game_speed

--- a/Assets/UI/TabWidgets/ShipForeignMenuTabWidget.gd
+++ b/Assets/UI/TabWidgets/ShipForeignMenuTabWidget.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
-	faction_indicator.texture = Global.FACTION_FLAGS[Global.faction]
+	faction_indicator.texture = Global.FACTIONS[Global.faction].emblem
 
 func update_data(context_data: Dictionary) -> void:
 	for data in context_data:

--- a/Assets/UI/TabWidgets/ShipMenuTabWidget.gd
+++ b/Assets/UI/TabWidgets/ShipMenuTabWidget.gd
@@ -9,4 +9,4 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
-	faction_indicator.texture = Global.FACTION_FLAGS[Global.faction]
+	faction_indicator.texture = Global.FACTIONS[Global.faction].emblem

--- a/Assets/World/Factions/Black.tres
+++ b/Assets/World/Factions/Black.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://byroyj0ef881s"]
+
+[ext_resource type="Texture2D" uid="uid://bcortca0u8ykt" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_black.png" id="1_kgd32"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_bvxfe"]
+
+[resource]
+script = ExtResource("2_bvxfe")
+name = "Black"
+emblem = ExtResource("1_kgd32")
+color = Color(0, 0, 0, 1)

--- a/Assets/World/Factions/Blue.tres
+++ b/Assets/World/Factions/Blue.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://ioxxr8upvcd5"]
+
+[ext_resource type="Texture2D" uid="uid://deo6bohl0lo5m" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_blue.png" id="1_8fyae"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_vvew0"]
+
+[resource]
+script = ExtResource("2_vvew0")
+name = "Blue"
+emblem = ExtResource("1_8fyae")
+color = Color(0, 0.278431, 0.709804, 1)

--- a/Assets/World/Factions/Bordeaux.tres
+++ b/Assets/World/Factions/Bordeaux.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://bcj6dsnxrm1j4"]
+
+[ext_resource type="Texture2D" uid="uid://dxfegp0js32rs" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_bordeaux.png" id="1_fndhj"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_xlfxc"]
+
+[resource]
+script = ExtResource("2_xlfxc")
+name = "Bordeaux"
+emblem = ExtResource("1_fndhj")
+color = Color(0.588235, 0.0196078, 0.160784, 1)

--- a/Assets/World/Factions/Cyan.tres
+++ b/Assets/World/Factions/Cyan.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://bdrykhu6m2mf3"]
+
+[ext_resource type="Texture2D" uid="uid://ifwoahknmsvh" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_cyan.png" id="1_avalm"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_wn412"]
+
+[resource]
+script = ExtResource("2_wn412")
+name = "Cyan"
+emblem = ExtResource("1_avalm")
+color = Color(0, 1, 1, 1)

--- a/Assets/World/Factions/DarkGreen.tres
+++ b/Assets/World/Factions/DarkGreen.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://nyv0c200hui5"]
+
+[ext_resource type="Texture2D" uid="uid://efpx6xwxpvrl" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_dark_green.png" id="1_ha5yc"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_e0jff"]
+
+[resource]
+script = ExtResource("2_e0jff")
+name = "Dark Green"
+emblem = ExtResource("1_ha5yc")
+color = Color(0, 0.619608, 0.0901961, 1)

--- a/Assets/World/Factions/FactionData.gd
+++ b/Assets/World/Factions/FactionData.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name FactionData
+
+@export var name: String
+@export var emblem: Texture2D
+@export var color: Color

--- a/Assets/World/Factions/Gray.tres
+++ b/Assets/World/Factions/Gray.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://c1c1ct71ifi3r"]
+
+[ext_resource type="Texture2D" uid="uid://dvld4fj3lq5xs" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_gray.png" id="1_q17nn"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_5f74a"]
+
+[resource]
+script = ExtResource("2_5f74a")
+name = "Gray"
+emblem = ExtResource("1_q17nn")
+color = Color(0.501961, 0.501961, 0.501961, 1)

--- a/Assets/World/Factions/Lime.tres
+++ b/Assets/World/Factions/Lime.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://bsm0256bhk4fm"]
+
+[ext_resource type="Texture2D" uid="uid://c5jntrmwtwijo" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_lime_green.png" id="1_wnfcc"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_vvqak"]
+
+[resource]
+script = ExtResource("2_vvqak")
+name = "Lime Green"
+emblem = ExtResource("1_wnfcc")
+color = Color(0, 1, 0, 1)

--- a/Assets/World/Factions/Magenta.tres
+++ b/Assets/World/Factions/Magenta.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://hbwgh4qp77d7"]
+
+[ext_resource type="Texture2D" uid="uid://dvamp0o0sdsyh" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_pink.png" id="1_1hwxn"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_otv4d"]
+
+[resource]
+script = ExtResource("2_otv4d")
+name = "Pink"
+emblem = ExtResource("1_1hwxn")
+color = Color(1, 0, 1, 1)

--- a/Assets/World/Factions/None.tres
+++ b/Assets/World/Factions/None.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://cgggd6g0sdwvu"]
+
+[ext_resource type="Texture2D" uid="uid://e4knd13xcgao" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_no_player.png" id="1_wg7t3"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_bfg22"]
+
+[resource]
+script = ExtResource("2_bfg22")
+name = "None"
+emblem = ExtResource("1_wg7t3")
+color = Color(0, 0, 0, 0)

--- a/Assets/World/Factions/Orange.tres
+++ b/Assets/World/Factions/Orange.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://blghtverl22rf"]
+
+[ext_resource type="Texture2D" uid="uid://d1lyhy8qooo8n" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_orange.png" id="1_8vwxm"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_lkf7g"]
+
+[resource]
+script = ExtResource("2_lkf7g")
+name = "Orange"
+emblem = ExtResource("1_8vwxm")
+color = Color(0.878431, 0.4, 0, 1)

--- a/Assets/World/Factions/Purple.tres
+++ b/Assets/World/Factions/Purple.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://bc1hbkb060dov"]
+
+[ext_resource type="Texture2D" uid="uid://djl0psvlm5a4m" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_purple.png" id="1_t71b6"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_ftyla"]
+
+[resource]
+script = ExtResource("2_ftyla")
+name = "Purple"
+emblem = ExtResource("1_t71b6")
+color = Color(0.501961, 0, 0.501961, 1)

--- a/Assets/World/Factions/Red.tres
+++ b/Assets/World/Factions/Red.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://dx1momqk6ij0k"]
+
+[ext_resource type="Texture2D" uid="uid://bgyonk7toefi1" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_red.png" id="1_3a7n1"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_qjukx"]
+
+[resource]
+script = ExtResource("2_qjukx")
+name = "Red"
+emblem = ExtResource("1_3a7n1")
+color = Color(0.980392, 0.0392157, 0.0392157, 1)

--- a/Assets/World/Factions/Teal.tres
+++ b/Assets/World/Factions/Teal.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://dpyb5112r5jd7"]
+
+[ext_resource type="Texture2D" uid="uid://blnx8imlxs7ca" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_teal.png" id="1_ab6ue"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_n40fg"]
+
+[resource]
+script = ExtResource("2_n40fg")
+name = "Teal"
+emblem = ExtResource("1_ab6ue")
+color = Color(0, 0.568627, 0.54902, 1)

--- a/Assets/World/Factions/White.tres
+++ b/Assets/World/Factions/White.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://d5fg7gfefl5s"]
+
+[ext_resource type="Texture2D" uid="uid://dq3alu7x7pcmh" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_white.png" id="1_8j3lj"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_n6ium"]
+
+[resource]
+script = ExtResource("2_n6ium")
+name = "White"
+emblem = ExtResource("1_8j3lj")
+color = Color(1, 1, 1, 1)

--- a/Assets/World/Factions/Yellow.tres
+++ b/Assets/World/Factions/Yellow.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="FactionData" load_steps=3 format=3 uid="uid://dihc0x5bluhku"]
+
+[ext_resource type="Texture2D" uid="uid://mwy8eit5qknk" path="res://Assets/UI/Images/TabWidget/Emblems/emblem_yellow.png" id="1_i7to4"]
+[ext_resource type="Script" path="res://Assets/World/Factions/FactionData.gd" id="2_ny0by"]
+
+[resource]
+script = ExtResource("2_ny0by")
+name = "Yellow"
+emblem = ExtResource("1_i7to4")
+color = Color(1, 0.839216, 0, 1)

--- a/Assets/World/Global.gd
+++ b/Assets/World/Global.gd
@@ -129,6 +129,24 @@ enum Faction {
 	BLACK,
 }
 
+const FACTIONS = [
+	preload("res://Assets/World/Factions/None.tres"),
+	preload("res://Assets/World/Factions/Red.tres"),
+	preload("res://Assets/World/Factions/Blue.tres"),
+	preload("res://Assets/World/Factions/DarkGreen.tres"),
+	preload("res://Assets/World/Factions/Orange.tres"),
+	preload("res://Assets/World/Factions/Purple.tres"),
+	preload("res://Assets/World/Factions/Cyan.tres"),
+	preload("res://Assets/World/Factions/Yellow.tres"),
+	preload("res://Assets/World/Factions/Magenta.tres"),
+	preload("res://Assets/World/Factions/Teal.tres"),
+	preload("res://Assets/World/Factions/Lime.tres"),
+	preload("res://Assets/World/Factions/Bordeaux.tres"),
+	preload("res://Assets/World/Factions/White.tres"),
+	preload("res://Assets/World/Factions/Gray.tres"),
+	preload("res://Assets/World/Factions/Black.tres"),
+]
+
 const RESOURCE_TYPES = [
 	null,
 	preload("res://Assets/UI/Icons/Resources/32/001.png"),
@@ -232,60 +250,6 @@ const RESOURCE_TYPES = [
 	preload("res://Assets/UI/Icons/Resources/32/099.png"),
 ]
 
-const FACTIONS = [
-	"None",
-	"Red",
-	"Blue",
-	"Dark Green",
-	"Orange",
-	"Purple",
-	"Cyan",
-	"Yellow",
-	"Pink",
-	"Teal",
-	"Lime Green",
-	"Bordeaux",
-	"White",
-	"Gray",
-	"Black",
-]
-
-const FACTION_FLAGS = [
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_no_player.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_red.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_blue.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_dark_green.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_orange.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_purple.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_cyan.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_yellow.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_pink.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_teal.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_lime_green.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_bordeaux.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_white.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_gray.png"),
-	preload("res://Assets/UI/Images/TabWidget/Emblems/emblem_black.png"),
-]
-
-const FACTION_COLORS = [
-	Color8(  0,   0,   0,   0), # None (transparent black).
-	Color8(250,  10,  10, 255), # Red.
-	Color8(  0,  71, 181, 255), # Sea Blue.
-	Color8(  0, 158,  23, 255), # Dark Green.
-	Color8(224, 102,   0, 255), # Orange.
-	Color8(128,   0, 128, 255), # Purple.
-	Color8(  0, 255, 255, 255), # Cyan.
-	Color8(255, 214,   0, 255), # Yellow.
-	Color8(255,   0, 255, 255), # Magenta.
-	Color8(  0, 145, 140, 255), # Teal.
-	Color8(  0, 255,   0, 255), # Lime Green.
-	Color8(150,   5,  41, 255), # Bordeaux Red.
-	Color8(255, 255, 255, 255), # White.
-	Color8(128, 128, 128, 255), # Gray.
-	Color8(  0,   0,   0, 255), # Black.
-]
-
 const MESSAGE_SCENE = preload("res://Assets/UI/Notification/Message.tscn")
 
 #const WINDOW_MODES = [
@@ -327,7 +291,7 @@ var has_traders := false
 var has_pirates := true
 var has_disasters := false
 
-var Game: Node3D = null
+var World: Node3D = null
 var PlayerStart: Node3D = null
 
 @warning_ignore("unused_private_class_variable")
@@ -360,29 +324,6 @@ func set_audio_volumes() -> void:
 	Audio.set_voice_volume(Config.voice_volume)
 
 func _input(event: InputEvent) -> void:
-	if Engine.is_editor_hint():
-		return
-
-	# Only available during gameplay
-	if get_tree().get_root().get_node_or_null("World/WorldEnvironment") != null:
-		if event.is_action_pressed("time_speed_up"):
-			Engine.time_scale += clamp(.1, 0, 2)
-			prints("Time Scale:", Engine.time_scale)
-		if event.is_action_pressed("time_slow_down"):
-			Engine.time_scale -= clamp(.1, 0, 2)
-			prints("Time Scale:", Engine.time_scale)
-		if event.is_action_pressed("time_reset"):
-			Engine.time_scale = 1
-			prints("Time Scale:", Engine.time_scale)
-
-		if event.is_action_pressed("pause_scene"):
-			get_tree().paused = !get_tree().paused
-			print(get_tree().paused)
-
-		if event.is_action_pressed("restart_scene"):
-			#warning-ignore:return_value_discarded
-			get_tree().reload_current_scene()
-
 	if event.is_action_pressed("toggle_fullscreen"):
 		var window_mode = Config.window_mode
 
@@ -394,6 +335,5 @@ func _input(event: InputEvent) -> void:
 		Config.window_mode = window_mode
 
 		#Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
-
-	if event.is_action_pressed("quit_game"):
+	elif event.is_action_pressed("quit_game"):
 		get_tree().quit()

--- a/Assets/World/Units/Ships/Merchants/Huker/Huker.gd
+++ b/Assets/World/Units/Ships/Merchants/Huker/Huker.gd
@@ -6,7 +6,7 @@ class_name Huker
 
 func update_faction_color() -> void:
 	if faction_color != null:
-		faction_color.modulate = Global.FACTION_COLORS[faction]
+		faction_color.modulate = Global.FACTIONS[faction].color
 
 		# Match rotation of the ship's color outline with the main texture rotation
 		faction_color.frame = _billboard.frame

--- a/Assets/World/World.gd
+++ b/Assets/World/World.gd
@@ -1,5 +1,4 @@
 extends Node3D
-class_name Game
 
 signal notification(message_type: int, message_text: String)
 signal game_speed_changed(new_game_speed: float)
@@ -15,7 +14,7 @@ var player: Player = null
 var ai_players = []
 
 func _ready() -> void:
-	Global.Game = self
+	Global.World = self
 	player_start = Global.PlayerStart
 
 	randomize()
@@ -26,9 +25,31 @@ func _process(_delta: float) -> void:
 	if not is_game_running:
 		start_game()
 
-# Notification test (press N within a game session)
 func _input(event: InputEvent) -> void:
-	if event.is_action_pressed("debug_raise_notification"):
+	# Only available during gameplay
+	if event.is_action_pressed("time_speed_up"):
+		get_viewport().set_input_as_handled()
+		Engine.time_scale += clamp(.1, 0, 2)
+		prints("Time Scale:", Engine.time_scale)
+	elif event.is_action_pressed("time_slow_down"):
+		get_viewport().set_input_as_handled()
+		Engine.time_scale -= clamp(.1, 0, 2)
+		prints("Time Scale:", Engine.time_scale)
+	elif event.is_action_pressed("time_reset"):
+		get_viewport().set_input_as_handled()
+		Engine.time_scale = 1
+		prints("Time Scale:", Engine.time_scale)
+	elif event.is_action_pressed("pause_scene"):
+		get_viewport().set_input_as_handled()
+		get_tree().paused = !get_tree().paused
+		prints("paused:", get_tree().paused)
+	elif event.is_action_pressed("restart_scene"):
+		get_viewport().set_input_as_handled()
+		#warning-ignore:return_value_discarded
+		get_tree().reload_current_scene()
+	elif event.is_action_pressed("debug_raise_notification"):
+		get_viewport().set_input_as_handled()
+		# Notification test (press N within a game session)
 		emit_signal("notification", 3, "This is a test notification.")
 
 func start_game() -> void:

--- a/Assets/World/World.tscn
+++ b/Assets/World/World.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=10 format=3 uid="uid://b3jx1swk07856"]
 
 [ext_resource type="PackedScene" uid="uid://dis2urkbeqvnk" path="res://Assets/Player/PlayerStart.tscn" id="1"]
+[ext_resource type="Script" path="res://Assets/World/World.gd" id="1_w7xx4"]
 [ext_resource type="MeshLibrary" uid="uid://lpmno4f5y77j" path="res://Assets/World/Terrain/TerrainMeshLibrary.tres" id="2"]
 [ext_resource type="PackedScene" uid="uid://ctbaljo7ulect" path="res://Assets/Player/PlayerCamera.tscn" id="4"]
-[ext_resource type="Script" path="res://Assets/World/Game.gd" id="5"]
 [ext_resource type="Script" path="res://Assets/World/Terrain.gd" id="7"]
 [ext_resource type="Script" path="res://Assets/World/AStarMap.gd" id="8"]
 [ext_resource type="MeshLibrary" path="res://Assets/World/Buildings/Streets/TrailMeshLibrary.meshlib" id="9"]
@@ -13,7 +13,7 @@
 size = Vector3(200, 0, 200)
 
 [node name="World" type="Node3D"]
-script = ExtResource("5")
+script = ExtResource("1_w7xx4")
 
 [node name="AStarMap" type="Node3D" parent="."]
 script = ExtResource("8")

--- a/Assets/World/WorldThing.gd
+++ b/Assets/World/WorldThing.gd
@@ -175,15 +175,15 @@ func _on_Area_input_event(camera: Node, event: InputEvent, position: Vector3, _n
 
 func _on_Area_mouse_entered() -> void:
 	prints("WorldThing::_on_Area_mouse_entered()")
-	if Global.Game.player and Global.Game.player.camera:
-		Global.Game.player.camera._on_WorldThing_mouse_entered(self)
+	if Global.World.player and Global.World.player.camera:
+		Global.World.player.camera._on_WorldThing_mouse_entered(self)
 	#_billboard.alpha_cut = SpriteBase3D.ALPHA_CUT_OPAQUE_PREPASS
 	_outline.visible = true
 
 func _on_Area_mouse_exited() -> void:
 	print("WorldThing::_on_Area_mouse_exited()")
-	if Global.Game.player and Global.Game.player.camera:
-		Global.Game.player.camera._on_WorldThing_mouse_exited(self)
+	if Global.World.player and Global.World.player.camera:
+		Global.World.player.camera._on_WorldThing_mouse_exited(self)
 	#_billboard.alpha_cut = SpriteBase3D.ALPHA_CUT_DISABLED
 	_outline.visible = false
 


### PR DESCRIPTION
This PR refactors some things in the global autoload script:
- Remove editor hint check (`Engine.is_editor_hint`), because the global autoload is not a `tool` script.
- Move gameplay controls input handling (reload current scene, etc.) to the `Game` script.
- Rename the `Game` script mentioned above to `World` in order to better match its node name in the `World.tscn` scene.
- Save factions as resources (`.tres` files), which is handy to edit properties in the editor (name, emblem and color).